### PR TITLE
:bug: paste should be performed from backed text input

### DIFF
--- a/ios/RCTBaseTextInputView+MediaInput.m
+++ b/ios/RCTBaseTextInputView+MediaInput.m
@@ -96,7 +96,7 @@ static NSArray *acceptedTypes;
         });
     } else {
         // Call the normal paste action
-        [super paste:sender];
+        [[self backedTextInputView] paste:sender];
     }
 }
 
@@ -106,7 +106,6 @@ static NSArray *acceptedTypes;
         return (BOOL)self.onImageChange;
     }
 
-    return [super canPerformAction:action withSender:sender];
+    return NO;
 }
-
 @end


### PR DESCRIPTION
Fixes #5 

Two things were done:
 - modifying the paste fallback to be applied to the text input and not the RCTView that contains it
 - return NO on every canPerformAction except paste as the backed text input has its own canPerformAction which is called independantly
  