### PR TITLE
Removed upper bound on react and react-native peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": ">=16.8.1 <18.0.x",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
+    "react": ">=16.8.1",
+    "react-native": ">=0.60.0-rc.0"
   },
   "devDependencies": {
     "react": "^16.9.0",


### PR DESCRIPTION
Dependency resolution fails to resolve with react >= `18.1.0`, which is the default for react-native >= `0.70.0`. react-native-image-keyboard still works with these, and will likely continue to work for new versions of react and react-native, so imo removing the upper bounds makes sense to avoid having to update the peer dependencies of this library with every update of react and react-native.